### PR TITLE
Prevent grandchild from crashing on exception

### DIFF
--- a/lib/bluepill/system.rb
+++ b/lib/bluepill/system.rb
@@ -181,8 +181,8 @@ module Bluepill
             # finally, replace grandchild with cmd
             ::Kernel.exec(*Shellwords.shellwords(cmd))
           rescue Exception => e
-            cmd_err_write.puts "Exception in grandchild: #{e.to_s}."
-            cmd_err_write.puts e.backtrace
+            (cmd_err_write.closed? ? STDERR : cmd_err_write).puts "Exception in grandchild: #{e.to_s}."
+            (cmd_err_write.closed? ? STDERR : cmd_err_write).puts e.backtrace
             exit 1
           end
         }


### PR DESCRIPTION
execute_blocking's grandchild can have an exception thrown after cmd_err_write.close, in which case the rescue block will crash.

This happened to me if the cmd to execute doesn't exist.
