### PR TITLE
Increate activesupport compatilibility range

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,12 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in bluepill.gemspec
 gemspec
 
-gem 'activesupport', '~> 3.0', :platforms => [:ruby_18, :jruby]
+if RUBY_PLATFORM =~ /jruby|java/ || RUBY_VERSION =~ /1.8|1.9.2/
+  gem 'activesupport', '~> 3.0'
+else
+  gem 'activesupport', '~> 4.1'
+end
+
 gem 'rake'
 
 group :doc do

--- a/bluepill.gemspec
+++ b/bluepill.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.description = %q{Bluepill keeps your daemons up while taking up as little resources as possible. After all you probably want the resources of your server to be used by whatever daemons you are running rather than the thing that's supposed to make sure they are brought back up, should they die or misbehave.}
   s.license     = 'MIT'
 
-  s.add_dependency 'activesupport', ['>= 3', '< 4.1']
+  s.add_dependency 'activesupport', ['>= 3', '< 5']
   s.add_dependency 'blue-daemons', '~> 1.1.11'
   s.add_dependency 'i18n', '~> 0.5'
   s.add_dependency 'state_machine', '~> 1.1'


### PR DESCRIPTION
Allow bluepill to be compatible with `activesupport -v4.1.x` thus with
`rails -v4.1.x`
