### PR TITLE
Update bluepill.rb to get around Rails bug

### DIFF
--- a/lib/bluepill.rb
+++ b/lib/bluepill.rb
@@ -9,6 +9,7 @@ require 'syslog'
 require 'timeout'
 require 'logger'
 
+require 'active_support'
 require 'active_support/inflector'
 require 'active_support/core_ext/hash'
 require 'active_support/core_ext/numeric'


### PR DESCRIPTION
Adds explicit active_support require to get around a funky Rails bug. See https://github.com/rails/rails/issues/14664
