### PR TITLE
Only write child pids to journal for bluepill daemonized processes

### DIFF
--- a/lib/bluepill/process.rb
+++ b/lib/bluepill/process.rb
@@ -478,7 +478,7 @@ module Bluepill
 
       # Construct a new process wrapper for each new found children
       new_children_pids.each do |child_pid|
-        ProcessJournal.append_pid_to_journal(name, child_pid)
+        ProcessJournal.append_pid_to_journal(name, child_pid) if daemonize?
         child_name = "<child(pid:#{child_pid})>"
         logger = self.logger.prefix_with(child_name)
 


### PR DESCRIPTION
When using bluepill to monitor a self daemonizing process such as unicorn, it will append the child pids to the bluepill journal. If a custom restart command is specified, the journal is never cleared and new child pids will be added to the journal without removing the old ones. Since the `start_process` method only append pids to the journal when bluepill is daemonizing the process, we should be consistent and do the same for the `refresh_children!` method.
