### PR TITLE
Fix typo

### DIFF
--- a/lib/bluepill/process.rb
+++ b/lib/bluepill/process.rb
@@ -286,7 +286,7 @@ module Bluepill
         if daemon_id
           ProcessJournal.append_pid_to_journal(name, daemon_id)
           children.each do|child|
-            ProcessJournal.append_pid_to_journal(name, child.actual_id)
+            ProcessJournal.append_pid_to_journal(name, child.actual_pid)
           end if self.monitor_children?
         end
         daemon_id


### PR DESCRIPTION
I believe it's a typo causing the following exception to occur, when restarting process with children, which are monitored:

```
ubuntu@ip-XXX-XXX-XXX-XXX:~$ sudo bluepill restart
Received error from server:
#<NoMethodError: undefined method `actual_id' for #<Bluepill::Process:0x00000002bed5c8>>
/var/lib/gems/2.2.0/gems/bluepill-0.0.69/lib/bluepill/process.rb:289:in `block in start_process'
```