### PR TITLE
fix bug with missing pid file

### DIFF
--- a/lib/bluepill/controller.rb
+++ b/lib/bluepill/controller.rb
@@ -86,7 +86,7 @@ module Bluepill
     def cleanup_bluepill_directory
       running_applications.each do |app|
         pid = pid_for(app)
-        next if !pid
+        next unless pid
         next if pid || System.pid_alive?(pid)
         pid_file = File.join(pids_dir, "#{app}.pid")
         sock_file = File.join(sockets_dir, "#{app}.sock")

--- a/lib/bluepill/controller.rb
+++ b/lib/bluepill/controller.rb
@@ -86,6 +86,7 @@ module Bluepill
     def cleanup_bluepill_directory
       running_applications.each do |app|
         pid = pid_for(app)
+        next if !pid
         next if pid || System.pid_alive?(pid)
         pid_file = File.join(pids_dir, "#{app}.pid")
         sock_file = File.join(sockets_dir, "#{app}.sock")


### PR DESCRIPTION
Ran into a problem running blue pill where if a pid file is missing for any running bluepill application, we wind up with an error when trying to run any other bluepill. 

In the case pasted below, testworker-husky was being run by bluepill but the expected pid file was not found. 