### PR TITLE
Fix ActiveSupport require

### DIFF
--- a/lib/bluepill.rb
+++ b/lib/bluepill.rb
@@ -10,8 +10,7 @@ require 'logger'
 
 require 'active_support'
 require 'active_support/inflector'
-require 'active_support/core_ext/hash'
-require 'active_support/core_ext/numeric'
+require 'active_support/core_ext'
 require 'active_support/duration'
 
 require 'bluepill/dsl/process_proxy'


### PR DESCRIPTION
When utilizing the core extensions of ActiveSupport you need to require the top level of ActiveSupport first to avoid an issue where you'll get an `uninitialized constant ActiveSupport::Autoload` error. This issue has been seen by numerous gems, all referencing back to rails/rails#14664