### PR TITLE
Replaced $CHILD_STATUS global var by $?

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,9 @@ Metrics/ParameterLists:
   Max: 4
   CountKeywordArgs: true
 
+Style/SpecialGlobalVars:
+  Enabled: false
+
 Style/AccessModifierIndentation:
   EnforcedStyle: outdent
 

--- a/lib/bluepill/system.rb
+++ b/lib/bluepill/system.rb
@@ -197,7 +197,7 @@ module Bluepill
         result = {
           stdout: cmd_out_read.read,
           stderr: cmd_err_read.read,
-          exit_code: $CHILD_STATUS.exitstatus,
+          exit_code: $?.exitstatus,
         }
 
         # We're done with these ends of the pipes as well


### PR DESCRIPTION
I leaned towards using the cryptic variable name instead of requiring `English` in the project, but I can do it the other way. See https://github.com/arya/bluepill/issues/207